### PR TITLE
Sf 50 Реализовать удаление обложки для плейлиста и трека

### DIFF
--- a/apps/musicfun-rtk/src/common/utils/buildQueryString.ts
+++ b/apps/musicfun-rtk/src/common/utils/buildQueryString.ts
@@ -1,4 +1,4 @@
-type QueryParamValue = string | number | (string | number)[]
+type QueryParamValue = string | number | (string | number)[] | undefined
 
 /**
  * Формирует строку запроса (query string) из объекта параметров.

--- a/apps/musicfun-rtk/src/features/playlists/api/playlistsApi.ts
+++ b/apps/musicfun-rtk/src/features/playlists/api/playlistsApi.ts
@@ -63,6 +63,10 @@ export const playlistsAPI = baseApi.injectEndpoints({
       },
       invalidatesTags: (_result, _error, { playlistId }) => [{ type: 'Playlist', id: playlistId }, 'Playlist'],
     }),
+    deletePlaylistCover: build.mutation<void, { playlistId: string }>({
+      query: ({ playlistId }) => ({ url: `playlists/${playlistId}/images/main`, method: 'DELETE' }),
+      invalidatesTags: (_result, _error, { playlistId }) => [{ type: 'Playlist', id: playlistId }, 'Playlist'],
+    }),
     reorderPlaylist: build.mutation<void, { playlistId: string; putAfterItemId: Nullable<string> }>({
       query: ({ playlistId, putAfterItemId }) => ({
         url: `playlists/${playlistId}/reorder`,
@@ -103,6 +107,7 @@ export const {
   useUpdatePlaylistMutation,
   useRemovePlaylistMutation,
   useUploadPlaylistCoverMutation,
+  useDeletePlaylistCoverMutation,
   useReorderPlaylistMutation,
   useLikePlaylistMutation,
   useDislikePlaylistMutation,

--- a/apps/musicfun-rtk/src/features/playlists/ui/PlaylistsPage/PlaylistsList/PlaylistItem/PlaylistCover/PlaylistCover.tsx
+++ b/apps/musicfun-rtk/src/features/playlists/ui/PlaylistsPage/PlaylistsList/PlaylistItem/PlaylistCover/PlaylistCover.tsx
@@ -3,8 +3,11 @@ import { Link, useLocation } from 'react-router'
 import noCover from '@/assets/img/no-cover.png'
 import { Path } from '@/common/routing'
 import { uploadCover } from '@/common/utils'
-import type { Playlist } from '../../../../../api/playlistsApi.types'
-import { useDeletePlaylistCoverMutation, useUploadPlaylistCoverMutation } from '../../../../../api/playlistsApi'
+import type { Playlist } from '@/features/playlists/api/playlistsApi.types.ts'
+import {
+  useDeletePlaylistCoverMutation,
+  useUploadPlaylistCoverMutation,
+} from '@/features/playlists/api/playlistsApi.ts'
 import s from './PlaylistCover.module.css'
 
 type Props = {

--- a/apps/musicfun-rtk/src/features/playlists/ui/PlaylistsPage/PlaylistsList/PlaylistItem/PlaylistCover/PlaylistCover.tsx
+++ b/apps/musicfun-rtk/src/features/playlists/ui/PlaylistsPage/PlaylistsList/PlaylistItem/PlaylistCover/PlaylistCover.tsx
@@ -4,7 +4,7 @@ import noCover from '@/assets/img/no-cover.png'
 import { Path } from '@/common/routing'
 import { uploadCover } from '@/common/utils'
 import type { Playlist } from '../../../../../api/playlistsApi.types'
-import { useUploadPlaylistCoverMutation } from '../../../../../api/playlistsApi'
+import { useDeletePlaylistCoverMutation, useUploadPlaylistCoverMutation } from '../../../../../api/playlistsApi'
 import s from './PlaylistCover.module.css'
 
 type Props = {
@@ -16,6 +16,7 @@ export const PlaylistCover = ({ playlist, editable = false }: Props) => {
   const location = useLocation()
 
   const [uploadPlaylistCover] = useUploadPlaylistCoverMutation()
+  const [deletePlaylistCover] = useDeletePlaylistCoverMutation()
 
   const uploadCoverHandler = (event: ChangeEvent<HTMLInputElement>) => {
     uploadCover({
@@ -23,6 +24,10 @@ export const PlaylistCover = ({ playlist, editable = false }: Props) => {
       maxSize: 5 * 1024 * 1024,
       onSuccess: (file) => uploadPlaylistCover({ playlistId: playlist.id, file }),
     })
+  }
+
+  const deleteCoverHandler = () => {
+    deletePlaylistCover({ playlistId: playlist.id })
   }
 
   const originalCover = playlist.attributes.images.main?.find((img) => img.type === 'original')
@@ -37,6 +42,7 @@ export const PlaylistCover = ({ playlist, editable = false }: Props) => {
           <input type="file" accept="image/jpeg,image/png,image/gif" onChange={uploadCoverHandler} />
         </div>
       )}
+      {originalCover && <button onClick={deleteCoverHandler}>Delete cover</button>}
     </div>
   )
 }

--- a/apps/musicfun-rtk/src/features/tracks/api/tracksApi.ts
+++ b/apps/musicfun-rtk/src/features/tracks/api/tracksApi.ts
@@ -256,6 +256,21 @@ export const tracksAPI = baseApi.injectEndpoints({
       },
       invalidatesTags: (_res, _err, { trackId }) => [{ type: 'Track', id: trackId }],
     }),
+    deleteCoverFromTrack: build.mutation<void, { trackId: string }>({
+      query: ({ trackId }) => ({
+        url: `playlists/tracks/${trackId}/cover`,
+        method: 'DELETE',
+      }),
+      async onQueryStarted({ trackId }, { dispatch, queryFulfilled }) {
+        try {
+          await queryFulfilled
+          dispatch(baseApi.util.invalidateTags(['Track', { type: 'Track', id: trackId }]))
+        } catch {
+          // При ошибке кеш не трогаем
+        }
+      },
+      invalidatesTags: (_res, _err, { trackId }) => [{ type: 'Track', id: trackId }],
+    }),
   }),
 })
 
@@ -264,6 +279,7 @@ export const {
   useFetchTracksQuery,
   useFetchTrackByIdQuery,
   useAddCoverToTrackMutation,
+  useDeleteCoverFromTrackMutation,
   useAddTrackToPlaylistMutation,
   useCreateTrackMutation,
   useDislikeMutation,

--- a/apps/musicfun-rtk/src/features/tracks/ui/TracksPage/TracksList/TrackItem/TrackCover/TrackCover.module.css
+++ b/apps/musicfun-rtk/src/features/tracks/ui/TracksPage/TracksList/TrackItem/TrackCover/TrackCover.module.css
@@ -1,3 +1,7 @@
 .cover {
   width: 150px;
 }
+
+.cover ~ button {
+  max-width: fit-content;
+}

--- a/apps/musicfun-rtk/src/features/tracks/ui/TracksPage/TracksList/TrackItem/TrackCover/TrackCover.tsx
+++ b/apps/musicfun-rtk/src/features/tracks/ui/TracksPage/TracksList/TrackItem/TrackCover/TrackCover.tsx
@@ -1,6 +1,6 @@
 import trackDefaultCover from '@/assets/img/track-default-cover.jpg'
 import { uploadCover } from '@/common/utils/uploadCover.ts'
-import { useAddCoverToTrackMutation } from '@/features/tracks/api/tracksApi.ts'
+import { useAddCoverToTrackMutation, useDeleteCoverFromTrackMutation } from '@/features/tracks/api/tracksApi.ts'
 import type { BaseAttributes, TrackDetails } from '@/features/tracks/api/tracksApi.types.ts'
 import type { ChangeEvent, MouseEvent } from 'react'
 import s from './TrackCover.module.css'
@@ -11,6 +11,7 @@ type Props<T extends BaseAttributes> = {
 
 export const TrackCover = <T extends BaseAttributes>({ track }: Props<T>) => {
   const [mutate] = useAddCoverToTrackMutation()
+  const [deleteCover] = useDeleteCoverFromTrackMutation()
 
   const uploadCoverHandler = (event: ChangeEvent<HTMLInputElement>) => {
     uploadCover({
@@ -18,6 +19,10 @@ export const TrackCover = <T extends BaseAttributes>({ track }: Props<T>) => {
       maxSize: 100 * 1024,
       onSuccess: (file) => mutate({ trackId: track.id, cover: file }),
     })
+  }
+
+  const deleteCoverHandler = () => {
+    deleteCover({ trackId: track.id })
   }
 
   const stopPropagationHandler = (e: MouseEvent<HTMLInputElement>) => e.stopPropagation()
@@ -33,6 +38,7 @@ export const TrackCover = <T extends BaseAttributes>({ track }: Props<T>) => {
         onChange={uploadCoverHandler}
         onClick={stopPropagationHandler}
       />
+      {originalCover && <button onClick={deleteCoverHandler}>Delete Cover</button>}
     </div>
   )
 }


### PR DESCRIPTION
- Обновлён API треков — новый endpoint: удаление обложки трека.
- Обновлён API плейлистов — новый endpoint: удаление обложки трека.
- Добавлена возможность удалить обложку трека и плейлиста

1. Playlists
<img width="306" height="255" alt="image" src="https://github.com/user-attachments/assets/cde12718-4983-41df-8429-605597e1dc96" />
<img width="256" height="224" alt="image" src="https://github.com/user-attachments/assets/d76443bc-92e7-42b5-8738-50e2b5401ce1" />

2. Tracks
<img width="187" height="204" alt="image" src="https://github.com/user-attachments/assets/f90953af-1aa2-41da-aa77-f89e8293608f" />
<img width="170" height="152" alt="image" src="https://github.com/user-attachments/assets/52f29b40-15a6-40f1-b9ed-b194c11ce32b" />


