### PR TITLE
MF-48 tanstak feat: added sorting, filtering & pagination to PlaylistsPage.tsx

### DIFF
--- a/apps/musicfun-tanstack-query/src/features/playlists/api/use-playlist.query.types.ts
+++ b/apps/musicfun-tanstack-query/src/features/playlists/api/use-playlist.query.types.ts
@@ -1,0 +1,10 @@
+export interface IPlaylistsQuery {
+  search?: string
+  pageNumber: number
+  pageSize?: number
+  userId?: string
+  sortBy?: 'addedAt' | 'likesCount'
+  sortDirection?: 'asc' | 'desc'
+  tagsIds?: string[]
+  trackId?: string
+}

--- a/apps/musicfun-tanstack-query/src/features/playlists/api/use-playlists.query.ts
+++ b/apps/musicfun-tanstack-query/src/features/playlists/api/use-playlists.query.ts
@@ -7,7 +7,7 @@ import type { IPlaylistsQuery } from './use-playlist.query.types.ts'
 export const usePlaylists = ({
   search,
   pageNumber,
-  pageSize = 10,
+  pageSize = 5,
   userId,
   sortBy,
   sortDirection,

--- a/apps/musicfun-tanstack-query/src/features/playlists/api/use-playlists.query.ts
+++ b/apps/musicfun-tanstack-query/src/features/playlists/api/use-playlists.query.ts
@@ -2,25 +2,35 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 
 import { getClient } from '@/shared/api/client.ts'
 
+import type { IPlaylistsQuery } from './use-playlist.query.types.ts'
+
 export const usePlaylists = ({
   search,
   pageNumber,
+  pageSize = 10,
   userId,
-}: {
-  search?: string
-  pageNumber: number
-  userId?: string
-}) => {
+  sortBy,
+  sortDirection,
+  tagsIds,
+  trackId,
+}: IPlaylistsQuery) => {
   const query = useQuery({
-    queryKey: ['playlists', { search, pageNumber, userId }],
+    queryKey: [
+      'playlists',
+      { search, pageNumber, pageSize, userId, sortBy, sortDirection, tagsIds, trackId },
+    ],
     queryFn: () => {
       return getClient().GET('/playlists', {
         params: {
           query: {
-            search: search && undefined,
+            search,
             pageNumber,
-            pageSize: 5,
+            pageSize,
             userId,
+            sortBy,
+            sortDirection,
+            tagsIds,
+            trackId,
           },
         },
       })

--- a/apps/musicfun-tanstack-query/src/features/playlists/api/use-playlists.query.ts
+++ b/apps/musicfun-tanstack-query/src/features/playlists/api/use-playlists.query.ts
@@ -23,13 +23,13 @@ export const usePlaylists = ({
       return getClient().GET('/playlists', {
         params: {
           query: {
-            search,
+            search: search || void 0,
             pageNumber,
             pageSize,
             userId,
             sortBy,
             sortDirection,
-            tagsIds,
+            tagsIds: tagsIds && tagsIds.length > 0 ? tagsIds : void 0,
             trackId,
           },
         },

--- a/apps/musicfun-tanstack-query/src/features/tags/api/use-tags.query.ts
+++ b/apps/musicfun-tanstack-query/src/features/tags/api/use-tags.query.ts
@@ -14,6 +14,6 @@ export const useTags = (search?: string) => {
         },
       })
     },
-    enabled: true, // Всегда загружаем теги
+    enabled: true,
   })
 }

--- a/apps/musicfun-tanstack-query/src/features/tags/api/use-tags.query.ts
+++ b/apps/musicfun-tanstack-query/src/features/tags/api/use-tags.query.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { getClient } from '@/shared/api/client.ts'
+
+export const useTags = (search?: string) => {
+  return useQuery({
+    queryKey: ['tags', search],
+    queryFn: () => {
+      return getClient().GET('/tags/search', {
+        params: {
+          query: {
+            search: search || '',
+          },
+        },
+      })
+    },
+    enabled: true, // Всегда загружаем теги
+  })
+}

--- a/apps/musicfun-tanstack-query/src/features/tags/index.ts
+++ b/apps/musicfun-tanstack-query/src/features/tags/index.ts
@@ -1,2 +1,3 @@
-export * from './api'
+export { MOCK_HASHTAGS, MOCK_5_HASHTAGS } from './api/tags-api'
+export { useTags } from './api/use-tags.query'
 export * from './ui'

--- a/apps/musicfun-tanstack-query/src/features/tags/index.ts
+++ b/apps/musicfun-tanstack-query/src/features/tags/index.ts
@@ -1,3 +1,3 @@
-export { MOCK_HASHTAGS, MOCK_5_HASHTAGS } from './api/tags-api'
+export { MOCK_5_HASHTAGS, MOCK_HASHTAGS } from './api/tags-api'
 export { useTags } from './api/use-tags.query'
 export * from './ui'

--- a/apps/musicfun-tanstack-query/src/pages/PlaylistsPage/PlaylistsPage.tsx
+++ b/apps/musicfun-tanstack-query/src/pages/PlaylistsPage/PlaylistsPage.tsx
@@ -33,7 +33,7 @@ export const PlaylistsPage = () => {
     () => ({
       search: debouncedSearch,
       pageNumber,
-      pageSize: 10,
+      pageSize: 5,
       sortBy,
       sortDirection,
       tagsIds: hashtags,
@@ -42,7 +42,7 @@ export const PlaylistsPage = () => {
   )
 
   const { data, isPending, isError } = usePlaylists(queryParams)
-  const { data: tagsData, isPending: isTagsLoading, isError: isTagsError } = useTags('')
+  const { data: tagsData, isPending: isTagsLoading } = useTags('')
 
   const resetPage = useCallback(() => {
     setPageNumber(1)

--- a/apps/musicfun-tanstack-query/src/pages/PlaylistsPage/PlaylistsPage.tsx
+++ b/apps/musicfun-tanstack-query/src/pages/PlaylistsPage/PlaylistsPage.tsx
@@ -1,4 +1,5 @@
-import { type ChangeEvent, useMemo } from 'react'
+import { useMemo } from 'react'
+import type { ChangeEvent } from 'react'
 import { useCallback } from 'react'
 import { useState } from 'react'
 
@@ -10,8 +11,8 @@ import { Autocomplete, Pagination, Typography } from '@/shared/components'
 import { useDebounceValue } from '@/shared/hooks'
 
 import { ContentList, PageWrapper, SearchTextField, SortSelect } from '../common'
-import type { ISortConfig, SortOption } from './PlaylistsPage.types.ts'
 import s from './PlaylistsPage.module.css'
+import type { ISortConfig, SortOption } from './PlaylistsPage.types.ts'
 
 const sortConfig: Record<SortOption, ISortConfig> = {
   newest: { sortBy: 'addedAt', sortDirection: 'desc' },

--- a/apps/musicfun-tanstack-query/src/pages/PlaylistsPage/PlaylistsPage.tsx
+++ b/apps/musicfun-tanstack-query/src/pages/PlaylistsPage/PlaylistsPage.tsx
@@ -1,7 +1,5 @@
-import { useMemo } from 'react'
 import type { ChangeEvent } from 'react'
-import { useCallback } from 'react'
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { PlaylistCard } from '@/features/playlists'
 import type { IPlaylistsQuery } from '@/features/playlists/api/use-playlist.query.types.ts'

--- a/apps/musicfun-tanstack-query/src/pages/PlaylistsPage/PlaylistsPage.tsx
+++ b/apps/musicfun-tanstack-query/src/pages/PlaylistsPage/PlaylistsPage.tsx
@@ -82,6 +82,8 @@ export const PlaylistsPage = () => {
     content = <span>Loading...</span>
   } else if (isError) {
     content = <span>Playlist loading error. Please try again later.</span>
+  } else if (data?.data?.data.length === 0) {
+    content = <span>No results found for your search.</span>
   } else if (data?.data) {
     content = (
       <>

--- a/apps/musicfun-tanstack-query/src/pages/PlaylistsPage/PlaylistsPage.types.ts
+++ b/apps/musicfun-tanstack-query/src/pages/PlaylistsPage/PlaylistsPage.types.ts
@@ -1,0 +1,8 @@
+import type { IPlaylistsQuery } from '@/features/playlists/api/use-playlist.query.types.ts'
+
+export type SortOption = 'mostLiked' | 'leastLiked' | 'newest' | 'oldest'
+
+export interface ISortConfig {
+  sortBy: IPlaylistsQuery['sortBy']
+  sortDirection: IPlaylistsQuery['sortDirection']
+}

--- a/apps/musicfun-tanstack-query/src/shared/api/schema.ts
+++ b/apps/musicfun-tanstack-query/src/shared/api/schema.ts
@@ -851,10 +851,10 @@ export interface components {
       search?: string
       /**
        * @description Поле, по которому выполняется сортировка
-       * @default publishedAt
+       * @default addedAt
        * @enum {string}
        */
-      sortBy: 'publishedAt' | 'likesCount'
+      sortBy: 'addedAt' | 'likesCount'
       /**
        * @description Направление сортировки (по возрастанию или убыванию)
        * @default desc
@@ -1019,7 +1019,7 @@ export interface operations {
         /** @description Строка для поиска по названию плейлиста */
         search?: string
         /** @description Поле, по которому выполняется сортировка */
-        sortBy?: 'publishedAt' | 'likesCount'
+        sortBy?: 'addedAt' | 'likesCount'
         /** @description Направление сортировки (по возрастанию или убыванию) */
         sortDirection?: 'asc' | 'desc'
         /** @description Фильтрация по ID тегов. Может быть передано несколько значений: tagsIds=tag1&tagsIds=tag2 */

--- a/apps/musicfun-tanstack-query/src/shared/components/Button/Button.tsx
+++ b/apps/musicfun-tanstack-query/src/shared/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx'
 import type { ComponentProps, ElementType } from 'react'
 
-import s from './button.module.css'
+import s from './Button.module.css'
 
 export type ButtonVariant = 'primary' | 'secondary'
 

--- a/apps/musicfun-tanstack-query/src/shared/hooks/index.ts
+++ b/apps/musicfun-tanstack-query/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './useDebounceValue'
 export * from './useGetId'

--- a/apps/musicfun-tanstack-query/src/shared/hooks/useDebounceValue.ts
+++ b/apps/musicfun-tanstack-query/src/shared/hooks/useDebounceValue.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+
+export const useDebounceValue = <T>(value: T, delay: number = 700): [T] => {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(handler)
+  }, [value, delay])
+
+  return [debounced]
+}


### PR DESCRIPTION
[issue: tanstak сортировка , фильтрация, пагинация плейлистов](https://github.com/it-incubator/musicfun-react-all-stacks/issues/48)

- Реализована функциональность сортировки плейлистов
- Добавлена система фильтрации по тегам
- Внедрена пагинация 

**Дополнительно:**  
Добавлен API-метод useTags для получения тегов с сервера