### PR TITLE
feat: set gradient color on pages without header

### DIFF
--- a/apps/rtk-query/src/pages/PlaylistPage/PlaylistPage.module.css
+++ b/apps/rtk-query/src/pages/PlaylistPage/PlaylistPage.module.css
@@ -1,5 +1,5 @@
 .playlistPage {
-  --page-gradient-color: #adbf22;
+  /* css */
 }
 
 .playlistOverview {

--- a/apps/rtk-query/src/pages/PlaylistPage/PlaylistPage.module.css
+++ b/apps/rtk-query/src/pages/PlaylistPage/PlaylistPage.module.css
@@ -1,7 +1,3 @@
-.playlistPage {
-  /* css */
-}
-
 .playlistOverview {
   margin-bottom: 46px;
 }

--- a/apps/rtk-query/src/pages/PlaylistPage/PlaylistPage.tsx
+++ b/apps/rtk-query/src/pages/PlaylistPage/PlaylistPage.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router'
 import { useMeQuery } from '@/features/auth'
 import { PlaylistOverview, useFetchPlaylistByIdQuery } from '@/features/playlists'
 import { TrackRowContainer, TracksTable, useFetchTracksInPlaylistQuery } from '@/features/tracks'
-import { usePageSearchParams } from '@/pages/common/hooks'
+import { usePageBackgroundColor, usePageSearchParams } from '@/pages/common/hooks'
 import { ImageType } from '@/shared/types/commonApi.types'
 import { getImageByType } from '@/shared/utils'
 
@@ -17,7 +17,7 @@ export const PlaylistPage = () => {
   const { debouncedSearch } = usePageSearchParams()
 
   const { id } = useParams()
-  const { data: playlist } = useFetchPlaylistByIdQuery(id!)
+  const { data: playlist, isSuccess } = useFetchPlaylistByIdQuery(id!)
   const { data: me } = useMeQuery()
 
   const isOwnPlaylist = me?.userId === playlist?.data.attributes.user.id
@@ -33,56 +33,69 @@ export const PlaylistPage = () => {
       track.attributes.title.toLowerCase().includes(debouncedSearch.toLowerCase())
     ) ?? []
 
+  const playlistCover =
+    playlist?.data.attributes.images &&
+    getImageByType(playlist?.data.attributes.images, ImageType.ORIGINAL)
+
+  const { dominantColor, canvasRef } = usePageBackgroundColor(playlistCover?.url, isSuccess)
+
   if (!playlist) {
     return <div>{t('playlists.title.playlists_not_found')}</div>
   }
-  const playlistCover = getImageByType(playlist?.data.attributes.images, ImageType.ORIGINAL)
 
   return (
-    <PageWithoutHeader className={s.playlistPage}>
-      <PlaylistOverview
-        className={s.playlistOverview}
-        title={playlist.data.attributes.title}
-        image={playlistCover?.url}
-        description={playlist.data.attributes.description}
-        tags={playlist.data.attributes.tags}
-      />
-      <div className={s.playlistToolbar}>
-        <SearchTextField placeholder={t('tracks.placeholder.search_tracks')} onChange={() => {}} />
-        <ControlPanel
-          className={s.playlistActions}
-          playlistId={playlist.data.id}
-          isOwnPlaylist={isOwnPlaylist}
-          reaction={playlist.data.attributes.currentUserReaction}
-          likesCount={playlist.data.attributes.likesCount}
-        />
-      </div>
-      {filteredTracks?.length > 0 ? (
-        <TracksTable
-          trackRows={filteredTracks.map((track, index) => ({
-            index,
-            id: track.id,
-            title: track.attributes.title,
-            imageSrc: getImageByType(track.attributes.images, ImageType.THUMBNAIL)?.url,
-            addedAt: track.attributes.addedAt,
-            artists: ['Artist 1', 'Artist 2'],
-            duration: 100,
-            likesCount: track.attributes.likesCount,
-            dislikesCount: track.attributes.dislikesCount,
-            currentUserReaction: track.attributes.currentUserReaction,
-            url: track.attributes.attachments[0].url,
-          }))}
-          renderTrackRow={(trackRow) => (
-            <TrackRowContainer
-              key={trackRow.id}
-              trackRow={trackRow}
-              userId={me?.userId}
-              playlistId={playlist.data.id}
+    <PageWithoutHeader className={s.playlistPage} backgroundColor={dominantColor}>
+      <canvas ref={canvasRef} style={{ display: 'none' }} />
+      {dominantColor && (
+        <>
+          <PlaylistOverview
+            className={s.playlistOverview}
+            title={playlist.data.attributes.title}
+            image={playlistCover?.url}
+            description={playlist.data.attributes.description}
+            tags={playlist.data.attributes.tags}
+          />
+          <div className={s.playlistToolbar}>
+            <SearchTextField
+              placeholder={t('tracks.placeholder.search_tracks')}
+              onChange={() => {}}
             />
+            <ControlPanel
+              className={s.playlistActions}
+              playlistId={playlist.data.id}
+              isOwnPlaylist={isOwnPlaylist}
+              reaction={playlist.data.attributes.currentUserReaction}
+              likesCount={playlist.data.attributes.likesCount}
+            />
+          </div>
+          {filteredTracks?.length > 0 ? (
+            <TracksTable
+              trackRows={filteredTracks.map((track, index) => ({
+                index,
+                id: track.id,
+                title: track.attributes.title,
+                imageSrc: getImageByType(track.attributes.images, ImageType.THUMBNAIL)?.url,
+                addedAt: track.attributes.addedAt,
+                artists: ['Artist 1', 'Artist 2'],
+                duration: 100,
+                likesCount: track.attributes.likesCount,
+                dislikesCount: track.attributes.dislikesCount,
+                currentUserReaction: track.attributes.currentUserReaction,
+                url: track.attributes.attachments[0].url,
+              }))}
+              renderTrackRow={(trackRow) => (
+                <TrackRowContainer
+                  key={trackRow.id}
+                  trackRow={trackRow}
+                  userId={me?.userId}
+                  playlistId={playlist.data.id}
+                />
+              )}
+            />
+          ) : (
+            <div>{t('tracks.label.no_tracks')}</div>
           )}
-        />
-      ) : (
-        <div>{t('tracks.label.no_tracks')}</div>
+        </>
       )}
     </PageWithoutHeader>
   )

--- a/apps/rtk-query/src/pages/PlaylistPage/PlaylistPage.tsx
+++ b/apps/rtk-query/src/pages/PlaylistPage/PlaylistPage.tsx
@@ -44,7 +44,7 @@ export const PlaylistPage = () => {
   }
 
   return (
-    <PageWithoutHeader className={s.playlistPage} backgroundColor={dominantColor}>
+    <PageWithoutHeader backgroundColor={dominantColor}>
       <canvas ref={canvasRef} style={{ display: 'none' }} />
       {dominantColor && (
         <>

--- a/apps/rtk-query/src/pages/TrackLyricsPage/TrackLyricsPage.module.css
+++ b/apps/rtk-query/src/pages/TrackLyricsPage/TrackLyricsPage.module.css
@@ -1,6 +1,4 @@
 .trackLyricsPage {
-  --page-gradient-color: #9a3426;
-
   position: relative;
 }
 

--- a/apps/rtk-query/src/pages/TrackLyricsPage/TrackLyricsPage.tsx
+++ b/apps/rtk-query/src/pages/TrackLyricsPage/TrackLyricsPage.tsx
@@ -3,7 +3,10 @@ import { useNavigate, useParams } from 'react-router'
 
 import { useFetchTrackByIdQuery } from '@/features/tracks'
 import { PageWithoutHeader } from '@/pages/common'
+import { usePageBackgroundColor } from '@/pages/common/hooks'
 import { ArrowBackIcon } from '@/shared/icons/ArrowBackIcon.tsx'
+import { ImageType } from '@/shared/types'
+import { getImageByType } from '@/shared/utils'
 
 import s from './TrackLyricsPage.module.css'
 
@@ -12,27 +15,36 @@ export const TrackLyricsPage = () => {
   const { id } = useParams()
   const navigate = useNavigate()
 
-  const { data: track, isLoading } = useFetchTrackByIdQuery({ trackId: id! })
+  const { data: track, isLoading, isSuccess } = useFetchTrackByIdQuery({ trackId: id! })
+
+  const trackCover =
+    track?.data.attributes.images &&
+    getImageByType(track?.data.attributes.images, ImageType.ORIGINAL)
+
+  const { dominantColor, canvasRef } = usePageBackgroundColor(trackCover?.url, isSuccess)
 
   const trackText = track?.data.attributes.lyrics || t('tracks.placeholder.no_lyrics')
 
   return (
-    <>
-      <PageWithoutHeader className={s.trackLyricsPage}>
-        <button
-          type="button"
-          className={s.button}
-          onClick={() => {
-            navigate(-1)
-          }}>
-          <ArrowBackIcon />
-          {t('tracks.button.go_back')}
-        </button>
+    <PageWithoutHeader className={s.trackLyricsPage} backgroundColor={dominantColor}>
+      <canvas ref={canvasRef} style={{ display: 'none' }} />
+      {dominantColor && (
+        <>
+          <button
+            type="button"
+            className={s.button}
+            onClick={() => {
+              navigate(-1)
+            }}>
+            <ArrowBackIcon />
+            {t('tracks.button.go_back')}
+          </button>
 
-        <div className={s.trackTextWrapper}>
-          {!isLoading && <p className={s.trackText}>{trackText}</p>}
-        </div>
-      </PageWithoutHeader>
-    </>
+          <div className={s.trackTextWrapper}>
+            {!isLoading && <p className={s.trackText}>{trackText}</p>}
+          </div>
+        </>
+      )}
+    </PageWithoutHeader>
   )
 }

--- a/apps/rtk-query/src/pages/TrackPage/TrackPage.module.css
+++ b/apps/rtk-query/src/pages/TrackPage/TrackPage.module.css
@@ -1,5 +1,5 @@
 .trackPage {
-  --page-gradient-color: #9a3426;
+  /* css */
 }
 
 .trackOverview {

--- a/apps/rtk-query/src/pages/TrackPage/TrackPage.module.css
+++ b/apps/rtk-query/src/pages/TrackPage/TrackPage.module.css
@@ -1,7 +1,3 @@
-.trackPage {
-  /* css */
-}
-
 .trackOverview {
   margin-bottom: 46px;
 }

--- a/apps/rtk-query/src/pages/TrackPage/TrackPage.tsx
+++ b/apps/rtk-query/src/pages/TrackPage/TrackPage.tsx
@@ -36,7 +36,7 @@ export const TrackPage = () => {
   }
 
   return (
-    <PageWithoutHeader className={s.trackPage} backgroundColor={dominantColor}>
+    <PageWithoutHeader backgroundColor={dominantColor}>
       <canvas ref={canvasRef} style={{ display: 'none' }} />
       {dominantColor && (
         <>

--- a/apps/rtk-query/src/pages/TrackPage/TrackPage.tsx
+++ b/apps/rtk-query/src/pages/TrackPage/TrackPage.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router'
 import { useMeQuery } from '@/features/auth'
 import { PlaylistCard, useFetchPlaylistsQuery } from '@/features/playlists'
 import { TrackOverview, useFetchTrackByIdQuery } from '@/features/tracks'
+import { usePageBackgroundColor } from '@/pages/common/hooks'
 import { Typography } from '@/shared/components'
 import { ImageType } from '@/shared/types/commonApi.types'
 import { getImageByType } from '@/shared/utils'
@@ -16,7 +17,7 @@ export const TrackPage = () => {
   const { t } = useTranslation()
 
   const { id } = useParams()
-  const { data: track } = useFetchTrackByIdQuery({ trackId: id! })
+  const { data: track, isSuccess } = useFetchTrackByIdQuery({ trackId: id! })
   const { data: me } = useMeQuery()
   const isTrackOwner = me?.userId === track?.data.attributes.user.id
 
@@ -24,46 +25,55 @@ export const TrackPage = () => {
 
   const { data: playlists } = useFetchPlaylistsQuery({ trackId: id! })
 
+  const trackCover =
+    track?.data.attributes.images &&
+    getImageByType(track?.data.attributes.images, ImageType.ORIGINAL)
+
+  const { dominantColor, canvasRef } = usePageBackgroundColor(trackCover?.url, isSuccess)
+
   if (!track) {
     return <div>{t('tracks.title.tracks_not_found')}</div>
   }
 
-  const trackCover = getImageByType(track?.data.attributes.images, ImageType.ORIGINAL)
-
   return (
-    <PageWithoutHeader className={s.trackPage}>
-      <TrackOverview
-        className={s.trackOverview}
-        title={track.data.attributes.title}
-        image={trackCover?.url}
-        addedAt={track.data.attributes.addedAt}
-        artists={track.data.attributes.artists.map((artist) => artist.name)}
-        tags={track.data.attributes.tags}
-      />
+    <PageWithoutHeader className={s.trackPage} backgroundColor={dominantColor}>
+      <canvas ref={canvasRef} style={{ display: 'none' }} />
+      {dominantColor && (
+        <>
+          <TrackOverview
+            className={s.trackOverview}
+            title={track.data.attributes.title}
+            image={trackCover?.url}
+            addedAt={track.data.attributes.addedAt}
+            artists={track.data.attributes.artists.map((artist) => artist.name)}
+            tags={track.data.attributes.tags}
+          />
 
-      <ControlPanel
-        trackId={track.data.id}
-        isOwnTrack={isTrackOwner}
-        reaction={track.data.attributes.currentUserReaction}
-        likesCount={track.data.attributes.likesCount}
-      />
+          <ControlPanel
+            trackId={track.data.id}
+            isOwnTrack={isTrackOwner}
+            reaction={track.data.attributes.currentUserReaction}
+            likesCount={track.data.attributes.likesCount}
+          />
 
-      <Typography variant="h2" className={s.title}>
-        {t('placeholder.which_playlist')}
-      </Typography>
+          <Typography variant="h2" className={s.title}>
+            {t('placeholder.which_playlist')}
+          </Typography>
 
-      {playlists?.data && (
-        <ContentList
-          data={playlists.data}
-          emptyMessage={t('playlists.title.playlists_not_found')}
-          renderItem={(playlist) => (
-            <PlaylistCard
-              id={playlist.id}
-              title={playlist.attributes.title}
-              imageSrc={getImageByType(playlist.attributes.images, ImageType.ORIGINAL)?.url}
+          {playlists?.data && (
+            <ContentList
+              data={playlists.data}
+              emptyMessage={t('playlists.title.not_found_playlists')}
+              renderItem={(playlist) => (
+                <PlaylistCard
+                  id={playlist.id}
+                  title={playlist.attributes.title}
+                  imageSrc={getImageByType(playlist.attributes.images, ImageType.ORIGINAL)?.url}
+                />
+              )}
             />
           )}
-        />
+        </>
       )}
     </PageWithoutHeader>
   )

--- a/apps/rtk-query/src/pages/UserPage/UserPage.module.css
+++ b/apps/rtk-query/src/pages/UserPage/UserPage.module.css
@@ -1,6 +1,4 @@
 .userPage {
-  --page-gradient-color: #b8a661;
-
   display: flex;
   flex-direction: column;
   gap: 24px;

--- a/apps/rtk-query/src/pages/UserPage/UserPage.tsx
+++ b/apps/rtk-query/src/pages/UserPage/UserPage.tsx
@@ -1,22 +1,11 @@
-import { selectProfileAvatar } from '@/features/profile'
 import { PageWithoutHeader } from '@/pages/common'
-import { usePageBackgroundColor } from '@/pages/common/hooks'
-import { useOwnerData } from '@/pages/UserPage/hooks'
-import { useAppSelector } from '@/shared/hooks'
+import { useUserPageBackgroundColor } from '@/pages/UserPage/hooks'
 
 import { UserInfo, UserTabs } from './ui'
 import s from './UserPage.module.css'
 
 export const UserPage = () => {
-  const { isProfileOwner, isMeQuerySuccess } = useOwnerData()
-  const profileAvatarUrl = useAppSelector(selectProfileAvatar)
-
-  const imageUrlForBackgroundColor = isProfileOwner ? profileAvatarUrl : null
-
-  const { dominantColor, canvasRef } = usePageBackgroundColor(
-    imageUrlForBackgroundColor,
-    isMeQuerySuccess
-  )
+  const { dominantColor, canvasRef } = useUserPageBackgroundColor()
 
   return (
     <PageWithoutHeader className={s.userPage} backgroundColor={dominantColor}>

--- a/apps/rtk-query/src/pages/UserPage/UserPage.tsx
+++ b/apps/rtk-query/src/pages/UserPage/UserPage.tsx
@@ -1,13 +1,32 @@
+import { selectProfileAvatar } from '@/features/profile'
 import { PageWithoutHeader } from '@/pages/common'
+import { usePageBackgroundColor } from '@/pages/common/hooks'
+import { useOwnerData } from '@/pages/UserPage/hooks'
+import { useAppSelector } from '@/shared/hooks'
 
 import { UserInfo, UserTabs } from './ui'
 import s from './UserPage.module.css'
 
 export const UserPage = () => {
+  const { isProfileOwner, isMeQuerySuccess } = useOwnerData()
+  const profileAvatarUrl = useAppSelector(selectProfileAvatar)
+
+  const imageUrlForBackgroundColor = isProfileOwner ? profileAvatarUrl : null
+
+  const { dominantColor, canvasRef } = usePageBackgroundColor(
+    imageUrlForBackgroundColor,
+    isMeQuerySuccess
+  )
+
   return (
-    <PageWithoutHeader className={s.userPage}>
-      <UserInfo />
-      <UserTabs />
+    <PageWithoutHeader className={s.userPage} backgroundColor={dominantColor}>
+      <canvas ref={canvasRef} style={{ display: 'none' }} />
+      {dominantColor && (
+        <>
+          <UserInfo />
+          <UserTabs />
+        </>
+      )}
     </PageWithoutHeader>
   )
 }

--- a/apps/rtk-query/src/pages/UserPage/hooks/index.ts
+++ b/apps/rtk-query/src/pages/UserPage/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useOwnerData.ts'
+export * from './useUserPageBackgroundColor.ts'

--- a/apps/rtk-query/src/pages/UserPage/hooks/useOwnerData.ts
+++ b/apps/rtk-query/src/pages/UserPage/hooks/useOwnerData.ts
@@ -5,7 +5,7 @@ import { useFetchPlaylistsQuery } from '@/features/playlists'
 import { useFetchTracksQuery } from '@/features/tracks'
 
 export const useOwnerData = () => {
-  const { data: user, isLoading } = useMeQuery()
+  const { data: user, isLoading, isSuccess: isMeQuerySuccess } = useMeQuery()
   const { userId: pageOwnerId } = useParams()
   const isProfileOwner = user?.userId === pageOwnerId
 
@@ -31,5 +31,5 @@ export const useOwnerData = () => {
     userLogin = tracks.data[0].attributes.user.name
   }
 
-  return { isProfileOwner, userLogin, tracks, playlists }
+  return { isProfileOwner, userLogin, tracks, playlists, isMeQuerySuccess }
 }

--- a/apps/rtk-query/src/pages/UserPage/hooks/useUserPageBackgroundColor.ts
+++ b/apps/rtk-query/src/pages/UserPage/hooks/useUserPageBackgroundColor.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react'
+
+import { selectProfileAvatar } from '@/features/profile'
+import { usePageBackgroundColor } from '@/pages/common/hooks'
+import { useOwnerData } from '@/pages/UserPage/hooks/useOwnerData.ts'
+import { useAppSelector } from '@/shared/hooks'
+import { decodeFileFromBase64 } from '@/shared/utils'
+
+export const useUserPageBackgroundColor = () => {
+  const { isProfileOwner, isMeQuerySuccess } = useOwnerData()
+  const profileAvatarUrl = useAppSelector(selectProfileAvatar)
+
+  const decodedProfileAvatarUrl = useMemo(
+    () => decodeFileFromBase64(profileAvatarUrl),
+    [profileAvatarUrl]
+  )
+  const imageUrlForBackgroundColor = isProfileOwner ? decodedProfileAvatarUrl : null
+  const isLocalUrlData = !!decodedProfileAvatarUrl
+  return usePageBackgroundColor(imageUrlForBackgroundColor, isMeQuerySuccess, isLocalUrlData)
+}

--- a/apps/rtk-query/src/pages/UserPage/ui/UserInfo/UserInfo.tsx
+++ b/apps/rtk-query/src/pages/UserPage/ui/UserInfo/UserInfo.tsx
@@ -26,7 +26,7 @@ export const UserInfo = () => {
   return (
     <div className={s.box}>
       <Avatar
-        src={profileAvatarUrl}
+        src={isProfileOwner ? profileAvatarUrl : undefined}
         fullName={isProfileOwner ? profileFullName : undefined}
         userLogin={userLogin}
       />

--- a/apps/rtk-query/src/pages/common/hooks/index.ts
+++ b/apps/rtk-query/src/pages/common/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './usePageBackgroundColor.ts'
 export * from './usePageSearchParams'

--- a/apps/rtk-query/src/pages/common/hooks/usePageBackgroundColor.ts
+++ b/apps/rtk-query/src/pages/common/hooks/usePageBackgroundColor.ts
@@ -19,6 +19,9 @@ export const usePageBackgroundColor = (
       img.crossOrigin = 'anonymous'
       img.src = isLocalUrlData ? url : url + '?' //to avoid CORS error
       img.onload = () => {
+        if (isLocalUrlData) {
+          URL.revokeObjectURL(url)
+        }
         const canvas = canvasRef.current
         if (canvas) {
           canvas.width = img.naturalWidth

--- a/apps/rtk-query/src/pages/common/hooks/usePageBackgroundColor.ts
+++ b/apps/rtk-query/src/pages/common/hooks/usePageBackgroundColor.ts
@@ -2,7 +2,11 @@ import { useEffect, useRef, useState } from 'react'
 
 const DEFAULT_BACKGROUND_COLOR = '#3333a3'
 
-export const usePageBackgroundColor = (url: string | null | undefined, isSuccess: boolean) => {
+export const usePageBackgroundColor = (
+  url: string | null | undefined,
+  isSuccess: boolean,
+  isLocalUrlData?: boolean
+) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const [dominantColor, setDominantColor] = useState<string>('')
 
@@ -13,7 +17,7 @@ export const usePageBackgroundColor = (url: string | null | undefined, isSuccess
     if (url) {
       const img = new Image()
       img.crossOrigin = 'anonymous'
-      img.src = url + '?' //to avoid CORS error
+      img.src = isLocalUrlData ? url : url + '?' //to avoid CORS error
       img.onload = () => {
         const canvas = canvasRef.current
         if (canvas) {

--- a/apps/rtk-query/src/pages/common/hooks/usePageBackgroundColor.ts
+++ b/apps/rtk-query/src/pages/common/hooks/usePageBackgroundColor.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react'
+
+const DEFAULT_BACKGROUND_COLOR = '#3333a3'
+
+export const usePageBackgroundColor = (url: string | null | undefined, isSuccess: boolean) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const [dominantColor, setDominantColor] = useState<string>('')
+
+  useEffect(() => {
+    if (isSuccess && !url) {
+      setDominantColor(DEFAULT_BACKGROUND_COLOR)
+    }
+    if (url) {
+      const img = new Image()
+      img.crossOrigin = 'anonymous'
+      img.src = url + '?' //to avoid CORS error
+      img.onload = () => {
+        const canvas = canvasRef.current
+        if (canvas) {
+          canvas.width = img.naturalWidth
+          canvas.height = img.naturalHeight
+          const ctx = canvas.getContext('2d', { willReadFrequently: true })
+          ctx!.drawImage(img, 0, 0)
+
+          const step = 5
+          let red = 0,
+            green = 0,
+            blue = 0,
+            pixelsCount = 0
+          for (let y = canvas.height * 0.25; y < canvas.height / 2; y += step) {
+            for (let x = canvas.width * 0.25; x < canvas.width / 2; x += step) {
+              const data = ctx!.getImageData(x, y, 1, 1).data
+              red += data[0]
+              green += data[1]
+              blue += data[2]
+              pixelsCount++
+            }
+          }
+          const color = `rgb(${Math.round(red / pixelsCount)}, ${Math.round(green / pixelsCount)}, ${Math.round(blue / pixelsCount)})`
+          setDominantColor(color)
+        }
+      }
+    }
+  }, [url, isSuccess])
+
+  return { dominantColor, canvasRef }
+}

--- a/apps/rtk-query/src/pages/common/ui/PageWithoutHeader/PageWithoutHeader.module.css
+++ b/apps/rtk-query/src/pages/common/ui/PageWithoutHeader/PageWithoutHeader.module.css
@@ -2,10 +2,4 @@
   min-height: calc(100vh - var(--player-height));
   margin-top: calc(0px - var(--header-height));
   padding: var(--header-height) 40px 0;
-  background: linear-gradient(
-    180deg,
-    var(--page-gradient-color, #3333a3) 0,
-    var(--color-bg-secondary) 300px,
-    var(--color-bg-secondary) 100%
-  );
 }

--- a/apps/rtk-query/src/pages/common/ui/PageWithoutHeader/PageWithoutHeader.tsx
+++ b/apps/rtk-query/src/pages/common/ui/PageWithoutHeader/PageWithoutHeader.tsx
@@ -2,19 +2,23 @@ import clsx from 'clsx'
 
 import s from './PageWithoutHeader.module.css'
 
-type PageWrapperProps = {
+type PageWithoutHeaderProps = {
   children: React.ReactNode
   className?: string
   backgroundColor?: string
 }
 
-export const PageWithoutHeader = ({ children, className, backgroundColor }: PageWrapperProps) => {
-  const style = backgroundColor
+export const PageWithoutHeader = ({
+  children,
+  className,
+  backgroundColor,
+}: PageWithoutHeaderProps) => {
+  const inlineStyles = backgroundColor
     ? { background: `linear-gradient(180deg, ${backgroundColor} 0, #141414 300px, #141414 100%)` }
     : {}
 
   return (
-    <div className={clsx(s.wrapper, className)} style={style}>
+    <div className={clsx(s.wrapper, className)} style={inlineStyles}>
       {children}
     </div>
   )

--- a/apps/rtk-query/src/pages/common/ui/PageWithoutHeader/PageWithoutHeader.tsx
+++ b/apps/rtk-query/src/pages/common/ui/PageWithoutHeader/PageWithoutHeader.tsx
@@ -2,11 +2,20 @@ import clsx from 'clsx'
 
 import s from './PageWithoutHeader.module.css'
 
-type PageWithoutHeaderProps = {
+type PageWrapperProps = {
   children: React.ReactNode
   className?: string
+  backgroundColor?: string
 }
 
-export const PageWithoutHeader = ({ children, className }: PageWithoutHeaderProps) => {
-  return <div className={clsx(s.wrapper, className)}>{children}</div>
+export const PageWithoutHeader = ({ children, className, backgroundColor }: PageWrapperProps) => {
+  const style = backgroundColor
+    ? { background: `linear-gradient(180deg, ${backgroundColor} 0, #141414 300px, #141414 100%)` }
+    : {}
+
+  return (
+    <div className={clsx(s.wrapper, className)} style={style}>
+      {children}
+    </div>
+  )
 }

--- a/apps/rtk-query/src/shared/utils/decode-file-from-base-64.ts
+++ b/apps/rtk-query/src/shared/utils/decode-file-from-base-64.ts
@@ -1,0 +1,16 @@
+export const decodeFileFromBase64 = (data: string | null) => {
+  if (!data) return null
+
+  const mimeType = data.split(';')[0].split(':')[1]
+  const base64Url = data.split(',')[1]
+
+  const binaryString = atob(base64Url)
+  const binaryLength = binaryString.length
+  const bytes = new Uint8Array(binaryLength)
+
+  for (let i = 0; i < binaryLength; i++) {
+    bytes[i] = binaryString.charCodeAt(i)
+  }
+  const blob = new Blob([bytes], { type: mimeType })
+  return URL.createObjectURL(blob)
+}

--- a/apps/rtk-query/src/shared/utils/index.ts
+++ b/apps/rtk-query/src/shared/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './build-query-string'
 export * from './convert-file-to-base-64'
+export * from './decode-file-from-base-64'
 export * from './get-image-by-type'
 export * from './get-user-initials'
 export * from './set-locale'


### PR DESCRIPTION
Closes #201

Added custom hook: calculate average values red/green/blue (rgb) of pixels of image. Analyzed area is the central area of ​​the image, the size of which is equal to half the width and height of the image. The resulting color is used for the background gradient. If there is no image, the default color is used.

On the another user page use default color. On the profile owner page analyze avatar image, if it's not there use the default color.